### PR TITLE
Fix image stretching on home page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -40,3 +40,7 @@ nav a img.site-logo {
     max-width: 50px !important;
     height: auto !important;
 } 
+
+#front-content-box img {
+    height: auto;
+}


### PR DESCRIPTION
The main screenshot on the home page is stretched. This will ensure it retains its proper aspect ratio.