### PR TITLE
Fix: deprecated `css.Sass` function on a concatenated CSS

### DIFF
--- a/layouts/partials/func/style/GetMainCSS.html
+++ b/layouts/partials/func/style/GetMainCSS.html
@@ -48,7 +48,7 @@ css asset directory we (unless condition below) add to aforementioned slice */}}
       {{ if eq .MediaType.SubType "x-scss" "x-sass" "scss" "sass" }}
         {{ if hugo.IsExtended }}
           {{/* as we cannot concatenate styles of different types, we sass/scss to be transformed to css beforehand */}}
-          {{ $assets_to_concat = $assets_to_concat | append (. | css.Sass) }}
+          {{ $assets_to_concat = $assets_to_concat | append (. | resources.ToCSS (dict "enableSourceMap" true "precision" 6)) }}
         {{ else }}
           {{ partial "func/warn" (printf "Processing of stylesheet %s of type %s has been skipped. You need Hugo Extended to process such files." .Name .MediaType.SubType) }}
         {{ end }}
@@ -63,9 +63,8 @@ css asset directory we (unless condition below) add to aforementioned slice */}}
   {{/* We proceed to concatenate the $assets_to_concat */}}
   {{ $style := . | resources.Concat "ananke/css/main.css" }}
 
-  {{/* We then use css.Sass to add sourceMap and minify */}}
-  {{ $options := dict "enableSourceMap" true "precision" 6 }}
-  {{ $style = $style | css.Sass $options | minify }}
+  {{/* We then minify the concatenated CSS. Sass processing is done earlier for SCSS/SASS files. */}}
+  {{ $style = $style | minify }}
   {{/* We fingerprint in production for cache busting purposes */}}
   {{ if eq (getenv "HUGO_ENV") "production" }}
     {{ $style = $style | fingerprint }}


### PR DESCRIPTION
was resolved by replacing it with `resources.ToCSS