### PR TITLE
Fix: Target files rather than directory

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -90,6 +90,7 @@ jobs:
           chmod 644 "$HOME/.ssh/known_hosts"
 
           # Use lftp in sftp mode because the server is SFTP-only (no shell)
+          # https://lftp.yar.ru/lftp-man.html
           sudo apt-get update && sudo apt-get install -y lftp
 
           # Create lftp script for robust sync
@@ -102,7 +103,7 @@ jobs:
           set net:persist-retries 1
           # Force key-only auth; prevent any password prompt
           set sftp:connect-program "ssh -i $HOME/.ssh/deploy_key -oBatchMode=yes -oPubkeyAuthentication=yes -oPasswordAuthentication=no -oKbdInteractiveAuthentication=no -oStrictHostKeyChecking=yes -p $SFTP_PORT"
-          mirror -R --parallel=4 --verbose ./public "$SFTP_TARGET_DIR"
+          mirror -R --parallel=4 --verbose --file=./public/* "$SFTP_TARGET_DIR"
           bye
           EOF
 


### PR DESCRIPTION
Source is ./public and destination is ./data targetting files should stop the mirror creating ./data/public but instead copy the content of public to data.