### PR TITLE
Highlight active navigation item with color and underline

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -192,7 +192,17 @@ nav a img.site-logo {
     width: 50px !important;
     max-width: 50px !important;
     height: auto !important;
-} 
+}
+
+nav ul {
+  margin: 0;
+}
+
+nav .is-active {
+  color: #99C1FF !important;
+  padding-bottom: 6px;
+  border-bottom: 2px solid #99C1FF;
+}
 
 #front-content-box img {
     height: auto;

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -11,9 +11,10 @@
       {{ partial "i18nlist.html" . }}
       {{ if .Site.Menus.main }}
         <ul class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr0 ml3" "pl0 mr3" }}">
+          {{ $currentPage := . }}
           {{ range .Site.Menus.main }}
-          <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
-            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
+          <li class="list f5 f4-ns fw4 dib pv2 {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
+            <a class="hover-white no-underline white-90 {{ if $currentPage.IsMenuCurrent "main" . }}is-active{{ end }}" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
               {{ .Name }}
             </a>
           </li>


### PR DESCRIPTION
Fixes #50

The nav item also has an underline, because a color alone didn't make it distinguishable enough IMO. Stronger colors looked off.

<img width="931" height="368" alt="image" src="https://github.com/user-attachments/assets/cb4523f8-363e-4e57-b88b-dc41a1c2c425" />
