### PR TITLE
display a date for news posts

### DIFF
--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+{{/*
+  This template is the same as the default and is here to demonstrate that if you have a content directory called "post" you can create a layouts directory, just for that section.
+   */}}
+  <article class="pa3 pa4-ns nested-copy-line-height">
+    <section class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
+      {{ .Content }}
+    </section>
+    <aside class="flex-ns flex-wrap justify-around mt5">
+      {{ range .Paginator.Pages }}
+        <div class="relative w-100 w-30-l mb4 bg-white">
+          {{ .Render "summary" }}
+        </div>
+      {{ end }}
+    </aside>
+    {{ template "_internal/pagination.html" . }}
+  </article>
+{{ end }}

--- a/layouts/news/summary-with-image.html
+++ b/layouts/news/summary-with-image.html
@@ -1,0 +1,16 @@
+  <div class="mb3 pa4 {{ $.Param "text_color" | default "mid-gray" }} overflow-hidden">
+    {{ if .Date }}
+      <div class="f6">
+        {{ .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) }}
+      </div>
+    {{ end }}
+    <h1 class="f3 near-black">
+      <a href="{{ .RelPermalink }}" class="link black dim">
+        {{ .Title }}
+      </a>
+    </h1>
+    <div class="nested-links f5 lh-copy nested-copy-line-height">
+      {{ .Summary  }}
+    </div>
+  <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+  </div>

--- a/layouts/news/summary.html
+++ b/layouts/news/summary.html
@@ -1,0 +1,16 @@
+  <div class="mb3 pa4 {{ $.Param "text_color" | default "mid-gray" }} overflow-hidden">
+    {{ if .Date }}
+      <div class="f6">
+        {{ .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) }}
+      </div>
+    {{ end }}
+    <h1 class="f3 near-black">
+      <a href="{{ .RelPermalink }}" class="link black dim">
+        {{ .Title }}
+      </a>
+    </h1>
+    <div class="nested-links f5 lh-copy nested-copy-line-height">
+      {{ .Summary  }}
+    </div>
+  <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+  </div>


### PR DESCRIPTION
This adds a date to news posts and removes some noise


the layout override for the folder 'post' provided with ananke is copied for 'news' to apply special layouting.

Actually only the category is replaced by the date.

- `list` describes the actual news site (unchanged copy)
-  `summary` is for the entries there
- `summary-with-image` is used in index.html

contributes to #55

before:
<img width="1402" height="1106" alt="grafik" src="https://github.com/user-attachments/assets/27f7fc5f-54a0-4525-8a55-8085fc91855c" />

after:
<img width="1402" height="1106" alt="grafik" src="https://github.com/user-attachments/assets/930b7ff7-35ea-468e-b693-5bd156465b1e" />


before:
<img width="1919" height="1102" alt="grafik" src="https://github.com/user-attachments/assets/af471dc2-0020-4896-a4fa-3a3b4b073679" />

after:
<img width="1919" height="1102" alt="grafik" src="https://github.com/user-attachments/assets/2de679b7-c501-4392-bb57-16492082efb2" />
