### PR TITLE
In setup script, use apt to install git instead of Snap

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 # Checks and installs hugo and git if necessary
-for cmd in hugo git
-do
-    if ! command -v $cmd &> /dev/null
-    then
-        echo "$cmd is not installed. Installing via Snap..."
-        sudo snap install $cmd
-    fi
-done
+if ! command -v hugo &> /dev/null
+then
+    echo "hugo is not installed. Installing via Snap..."
+    sudo snap install hugo
+fi
+
+if ! command -v git &> /dev/null
+then
+    echo  "git is not installed. Installing  via apt..."
+    sudo apt update
+    sudo apt install -y git
+fi
 
 # Checks for Github directory in home directory and changes into it
 if [ ! -d "$HOME/Github" ]; then


### PR DESCRIPTION
There is no (official) git Snap package, so this script would have failed when being used on a system that does not come with git pre-installed. This can be addressed by installing git via apt. (or potentially by using one of the unofficial git snaps from snapcraft, but I'm unsure how well-maintained or recommended these are)