### PR TITLE
Update Archive Link

### DIFF
--- a/themes/ananke/layouts/partials/site-footer.html
+++ b/themes/ananke/layouts/partials/site-footer.html
@@ -7,6 +7,5 @@
   </a>
     <div>{{ partial "social-follow.html" . }}</div>
   </div>
-<div><span><a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="/archives/">Kubuntu Archives</a>
-</span><span style="font-style: italic; color: white"><- old kubuntu.org site pre 24.04</span></div>
+<div><span><a class="f5 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="https://web.archive.org/web/20231102232909/https://kubuntu.org/">Kubuntu.org Archive</a>
 </footer>


### PR DESCRIPTION
Fixes #56: Updates the archived site link to use Wayback Machine and removes the pointer

<img width="213" height="90" alt="Footer" src="https://github.com/user-attachments/assets/2d453ebc-59b2-4b81-9612-b8c5ff0a0a74" />
